### PR TITLE
Update desktop extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Memory Box MCP Server will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-09-20
+
+### Changed
+- **Desktop Extension Format Update**:
+  - Updated from `.dxt` to `.mcpb` file extension following Anthropic's naming convention change
+  - Updated manifest format to use `manifest_version: "0.2"` per latest MCPB specification
+  - All functionality remains the same - this is purely a format update for compatibility
+
+- **Documentation Updates**:
+  - Updated README.md to reference `.mcpb` files instead of `.dxt`
+  - Updated DESKTOP_EXTENSION.md with new file extension and installation instructions
+  - Updated build scripts to generate `.mcpb` archives
+
+### Fixed
+- Resolved "Invalid manifest. Unrecognized keys in object" errors in Claude Desktop
+- Fixed compatibility with latest Claude Desktop extension loading system
+
 ## [1.0.0] - 2025-07-31
 
 ### Added

--- a/DESKTOP_EXTENSION.md
+++ b/DESKTOP_EXTENSION.md
@@ -4,7 +4,7 @@ This guide covers the Memory Box Desktop Extension for Claude Desktop, providing
 
 ## What is a Desktop Extension?
 
-Desktop Extensions (.dxt files) are packaged MCP servers that can be installed directly into Claude Desktop without manual configuration. They provide:
+Desktop Extensions (.mcpb files) are packaged MCP servers that can be installed directly into Claude Desktop without manual configuration. They provide:
 
 - **One-click installation** - No manual editing of configuration files
 - **User-friendly configuration** - Settings UI within Claude Desktop
@@ -16,11 +16,11 @@ Desktop Extensions (.dxt files) are packaged MCP servers that can be installed d
 ### Method 1: Download from GitHub Releases (Recommended)
 
 1. Visit the [Memory Box MCP Releases page](https://github.com/amotivv/memory-box-mcp/releases)
-2. Download the latest `memory-box.dxt` file
+2. Download the latest `memory-box.mcpb` file
 3. Open Claude Desktop
 4. Navigate to Settings → Extensions
 5. Click "Install from file"
-6. Select the downloaded `memory-box.dxt` file
+6. Select the downloaded `memory-box.mcpb` file
 7. Configure your settings in the extension configuration panel
 
 ### Method 2: Build from Source
@@ -38,7 +38,7 @@ npm install
 # Build the extension
 npm run build-extension
 
-# The extension will be at dist/memory-box.dxt
+# The extension will be at dist/memory-box.mcpb
 ```
 
 ## Configuration
@@ -134,7 +134,7 @@ The extension provides all Memory Box tools:
 
 When a new version is available:
 
-1. Download the latest `memory-box.dxt` from releases
+1. Download the latest `memory-box.mcpb` from releases
 2. In Claude Desktop, go to Settings → Extensions
 3. Uninstall the current version
 4. Install the new version
@@ -178,7 +178,7 @@ If you're running your own Memory Box instance:
 ### Extension Structure
 
 ```
-memory-box.dxt
+memory-box.mcpb
 ├── manifest.json      # Extension metadata and configuration
 ├── icon.png          # Extension icon
 └── server/           # MCP server files
@@ -194,7 +194,7 @@ To create a custom build:
 1. Modify the source code as needed
 2. Update `manifest.json` with your changes
 3. Run `npm run build-extension`
-4. Test the generated `.dxt` file
+4. Test the generated `.mcpb` file
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ The server has been installed and configured for use with Cline. Note that you n
 
 The easiest way to use Memory Box with Claude Desktop is through the Desktop Extension:
 
-1. Download the latest `memory-box.dxt` file from the [releases page](https://github.com/amotivv/memory-box-mcp/releases)
+1. Download the latest `memory-box.mcpb` file from the [releases page](https://github.com/amotivv/memory-box-mcp/releases)
 2. Open Claude Desktop
 3. Go to Settings > Extensions
 4. Click "Install from file"
-5. Select the downloaded `memory-box.dxt` file
+5. Select the downloaded `memory-box.mcpb` file
 6. Configure your Memory Box API token in the extension settings
 
 The extension will automatically configure all necessary environment variables and tools.
@@ -399,7 +399,7 @@ To build the Desktop Extension package:
    npm run build-extension
    ```
 
-3. The built extension will be available at `dist/memory-box.dxt`
+3. The built extension will be available at `dist/memory-box.mcpb`
 
 ### Release Process
 
@@ -407,4 +407,4 @@ To build the Desktop Extension package:
 2. Update `CHANGELOG.md` with new changes
 3. Commit changes
 4. Create a new GitHub release
-5. Upload the `memory-box.dxt` file as a release asset
+5. Upload the `memory-box.mcpb` file as a release asset

--- a/desktop-extension/manifest.json
+++ b/desktop-extension/manifest.json
@@ -1,9 +1,8 @@
 {
-  "dxt_version": "0.1",
-  "id": "memory-box-mcp",
+  "manifest_version": "0.2",
   "name": "memory-box-mcp",
   "display_name": "Memory Box",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Semantic memory storage and retrieval for Claude Desktop",
   "long_description": "Memory Box enables Claude to store and retrieve memories using semantic search. Save important information, search by meaning, organize in buckets, and maintain a persistent knowledge base across conversations. Features include bucket organization, relationship management, usage tracking, and more.",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-box-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A Model Context Protocol Server for Memory Box - semantic memory storage and retrieval",
   "private": true,
   "type": "module",

--- a/scripts/build-extension-flat.js
+++ b/scripts/build-extension-flat.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
 /**
- * Flat structure build script for creating Memory Box Desktop Extension (.dxt)
+ * Flat structure build script for creating Memory Box Desktop Extension (.mcpb)
  * Matches the structure of working extensions like Limitless
  * 
  * This script:
  * 1. Compiles TypeScript
  * 2. Creates a flat structure with package.json at root
  * 3. Installs dependencies at root level
- * 4. Creates a .dxt archive
+ * 4. Creates a .mcpb archive
  */
 
 import fs from 'fs';
@@ -159,9 +159,9 @@ async function build() {
       // Ignore errors
     }
     
-    // Step 9: Create .dxt archive
-    console.log('9. Creating .dxt archive...');
-    const outputPath = path.join(DIST_DIR, 'memory-box.dxt');
+    // Step 9: Create .mcpb archive
+    console.log('9. Creating .mcpb archive...');
+    const outputPath = path.join(DIST_DIR, 'memory-box.mcpb');
     
     await new Promise((resolve, reject) => {
       const output = fs.createWriteStream(outputPath);


### PR DESCRIPTION
  - Updated from `.dxt` to `.mcpb` file extension following Anthropic's naming convention change
  - Updated manifest format to use `manifest_version: "0.2"` per latest MCPB specification
  - All functionality remains the same - this is purely a format update for compatibility